### PR TITLE
don't notify when username is a substring

### DIFF
--- a/watchlist.js
+++ b/watchlist.js
@@ -59,7 +59,7 @@ WatchList.prototype.check = function (from, channel, message) {
 
   var me = this;
   Object.keys(this.users).forEach(function (user) {
-    if (RegExp(user).test(message)) {
+    if (RegExp([^a-z]user[^a-z]).test(message)) {
       send_notification(
         me.users[user].email,
         channel,


### PR DESCRIPTION
ex: markl: it's like my nightmare of passing undefined around i javascript all over again :'(
'tma' is a substring of 'nightmare'
